### PR TITLE
Version 0.1.2 (Repeater fix, Float conversion, CKEditor support)

### DIFF
--- a/ImageCropRatios.js
+++ b/ImageCropRatios.js
@@ -5,7 +5,7 @@
 		name = name.replace(/[\[]/, '\\[').replace(/[\]]/, '\\]');
 		var regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
 		var results = regex.exec(location.search);
-		return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
+		return results === null ? false : decodeURIComponent(results[1].replace(/\+/g, ' '));
 	}
 
 	// Set crop aspect ratio
@@ -20,13 +20,11 @@
 
 	$(document).ready(function() {
 
-		// Get aspect ratios from PW config
-		var parent_config = window.parent.ProcessWire.config;
 		var image_field_name = getUrlParameter('field');
-		var ratios = parent_config['icr_ratios_' + image_field_name];
+		var ratios = (image_field_name === false) ? window.parent.ProcessWire.config.icr_ratios_default : window.parent['icr_ratios_' + image_field_name];
 
 		// Add select element
-		var $el = $('<label>' + parent_config.icr_label + ':&nbsp;</label>');
+		var $el = $('<label>' + ProcessWire.config.icr_label + ':&nbsp;</label>');
 		var $select = $('<select id="icr_ratio"></select>');
 		$.each(ratios, function(index, value) {
 			$select.append('<option value="' + index + '">' + value + '</option>');

--- a/ImageCropRatios.module
+++ b/ImageCropRatios.module
@@ -9,7 +9,7 @@ class ImageCropRatios extends WireData implements Module, ConfigurableModule {
 		return array(
 			'title' => 'Image Crop Ratios',
 			'summary' => 'Allows preset aspect ratios to be defined per image field for the ProcessWire image crop tool.',
-			'version' => '0.1.0',
+			'version' => '0.1.1',
 			'author' => 'Robin Sallis',
 			'href' => 'https://github.com/Toutouwai/ImageCropRatios',
 			'icon' => 'crop',
@@ -53,6 +53,7 @@ EOT;
 	protected function afterRenderReady(HookEvent $event) {
 		/* @var InputfieldImage $inputfield */
 		$inputfield = $event->object;
+        $page = $inputfield->hasPage;
 		$field = $inputfield->hasField;
 		$config = $this->wire('config');
 		$ratios = [];
@@ -72,7 +73,8 @@ EOT;
 			$value = floatval($numbers[0]) / floatval($numbers[1]);
 			$ratios["_$value"] = $label; // Prefix to force treatment as string
 		}
-		$config->js("icr_ratios_{$field->name}", $ratios);
+        $fieldName = ($page instanceof RepeaterPage) ? $field->name . "_repeater{$page->id}" : $field->name;
+		$config->js("icr_ratios_{$fieldName}", $ratios);
 		$config->js('icr_label', $this->_('Ratio'));
 	}
 

--- a/ImageCropRatios.module
+++ b/ImageCropRatios.module
@@ -9,7 +9,7 @@ class ImageCropRatios extends WireData implements Module, ConfigurableModule {
 		return array(
 			'title' => 'Image Crop Ratios',
 			'summary' => 'Allows preset aspect ratios to be defined per image field for the ProcessWire image crop tool.',
-			'version' => '0.1.1',
+			'version' => '0.1.2',
 			'author' => 'Robin Sallis',
 			'href' => 'https://github.com/Toutouwai/ImageCropRatios',
 			'icon' => 'crop',
@@ -70,7 +70,7 @@ EOT;
 			$label = !empty($pieces[1]) ? $pieces[1] : $value;
 			$numbers = explode(':', $value);
 			if(count($numbers) !== 2) continue;
-			$value = floatval($numbers[0]) / floatval($numbers[1]);
+			$value = (string) str_replace(',', '.', round((float) $numbers[0] / (float) $numbers[1], 5));
 			$ratios["_$value"] = $label; // Prefix to force treatment as string
 		}
         $fieldName = ($page instanceof RepeaterPage) ? $field->name . "_repeater{$page->id}" : $field->name;

--- a/ImageCropRatios.module
+++ b/ImageCropRatios.module
@@ -38,45 +38,63 @@ EOT;
 	 * Ready
 	 */
 	public function ready() {
-		$this->addHookAfter('InputfieldImage::renderReadyHook', $this, 'afterRenderReady');
+		$this->addHookAfter('InputfieldImage::render', $this, 'afterRender');
+        $this->addHookAfter('ProcessPageEdit::buildForm', $this, 'afterBuildForm');
 		$this->addHookBefore('ProcessPageEditImageSelect::executeEdit', $this, 'beforeImageEdit');
 		$this->addHookAfter('InputfieldImage::getConfigInputfields', $this, 'addConfig');
 		$this->addHookAfter('InputfieldImage::getConfigAllowContext', $this, 'allowContext');
 	}
 
 	/**
-	 * After InputfieldImage::renderReadyHook
+	 * After InputfieldImage::afterRender
 	 * Add config field to InputfieldImage
 	 *
 	 * @param HookEvent $event
 	 */
-	protected function afterRenderReady(HookEvent $event) {
+	protected function afterRender(HookEvent $event) {
 		/* @var InputfieldImage $inputfield */
 		$inputfield = $event->object;
-        $page = $inputfield->hasPage;
 		$field = $inputfield->hasField;
-		$config = $this->wire('config');
-		$ratios = [];
 		$ratios_str = $field->aspect_ratios;
 		if(!$ratios_str) $ratios_str = $this->default_aspect_ratios;
-		$lines = explode("\n", str_replace("\r", "", $ratios_str));
-		foreach($lines as $line) {
-			if($line === '-') {
-				$ratios['auto'] = '';
-				continue;
-			}
-			$pieces = explode('=', $line, 2);
-			$value = $pieces[0];
-			$label = !empty($pieces[1]) ? $pieces[1] : $value;
-			$numbers = explode(':', $value);
-			if(count($numbers) !== 2) continue;
-			$value = (string) str_replace(',', '.', round((float) $numbers[0] / (float) $numbers[1], 5));
-			$ratios["_$value"] = $label; // Prefix to force treatment as string
-		}
-        $fieldName = ($page instanceof RepeaterPage) ? $field->name . "_repeater{$page->id}" : $field->name;
-		$config->js("icr_ratios_{$fieldName}", $ratios);
-		$config->js('icr_label', $this->_('Ratio'));
+		$ratios_json = json_encode($this->getRatios($ratios_str));
+        $event->return .= "<script>var icr_ratios_{$inputfield->name} = $ratios_json;</script>";
 	}
+
+    /**
+     * After ProcessPageEdit::buildForm
+     * Add default configuration.
+     * Needed for inline image edit in CKE
+     *
+     * @param HookEvent $event
+     */
+    protected function afterBuildForm(HookEvent $event) {
+        $this->config->js("icr_ratios_default", $this->getRatios($this->default_aspect_ratios));
+    }
+
+    /**
+     * Get configurations as array
+     *
+     * @param String $ratios_str
+     */
+    protected function getRatios($ratios_str) {
+        $ratios = array();
+        $lines = explode("\n", str_replace("\r", "", $ratios_str));
+        foreach($lines as $line) {
+            if($line === '-') {
+                $ratios['auto'] = '';
+                continue;
+            }
+            $pieces = explode('=', $line, 2);
+            $value = $pieces[0];
+            $label = !empty($pieces[1]) ? $pieces[1] : $value;
+            $numbers = explode(':', $value);
+            if(count($numbers) !== 2) continue;
+            $value = (string) number_format((float) $numbers[0] / (float) $numbers[1], 5, '.', '');
+            $ratios["_$value"] = $label; // Prefix to force treatment as string
+        }
+        return $ratios;
+    }
 
 	/**
 	 * Before ProcessPageEditImageSelect::executeEdit
@@ -91,6 +109,7 @@ EOT;
 		$version = $info['version'];
 		$config->scripts->add($config->urls->{$this} . "{$this}.js?v={$version}");
 		$config->styles->add($config->urls->{$this} . "{$this}.css?v={$version}");
+        $config->js('icr_label', $this->_('Ratio'));
 	}
 
 	/**


### PR DESCRIPTION
Hey Robin, 

you're right. Repeater support didn't work like that with AJAX. Your solution works perfectly. I've adopted it, too. 👍 

But the changes with the decimal point are not correct and do not work. Depending on which local is set, e.g.` setlocale(LC_ALL, 'de_DE.UTF-8');` PHP internally changes the decimal point from a (.) to a (,) AFTER the floats operation. In JavaScript, however, the float number must have a dot (.), otherwise it won't work. This means that without the conversion after the calculation, the value in the JS array will contain `"_1,33333":"4:3"` instead of `"_1.33333":"4:3"`. 

But I've changed my solution for the conversion. I now use `number_format()`, because this kills two birds with one stone. The function also rounds directly and limits the decimal places.

I also noticed that the module does not work with inline images in the CKEditor. The reason is that no "field" parameter is passed in the URL when the editor is opened. I added this feature with this version. The default configuration of the module is used for this. In order not to be redundant, I have outsourced the building of the ratio array to a separate function.

Hope you can do something with the suggestions and changes. :blush: :beers: